### PR TITLE
fix: env var not passed to sed properly

### DIFF
--- a/.github/workflows/cron-coverage.yaml
+++ b/.github/workflows/cron-coverage.yaml
@@ -85,7 +85,7 @@ jobs:
       run: |
         # setup file - coverage.json
         # use template.json to create/replace coverage.json
-        sed -e 's/TPL_LABEL/$LABEL/g;s/TPL_LCOLOR/$LCOLOR/g;s/TPL_MESSAGE/$MESSAGE/g;s/TPL_COLOR/$COLOR/g' template.json > coverage.json
+        sed -e 's/TPL_LABEL/${{ env.LABEL }}/g;s/TPL_LCOLOR/${{ env.LCOLOR }}/g;s/TPL_MESSAGE/${{ env.MESSAGE }}/g;s/TPL_COLOR/${{ env.COLOR }}/g' template.json > coverage.json
 
     - name: Push commits to badge branch
       run: |


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_env var is not passed to sed correctly and will render the code coverage badge not working properly_


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_fix env var before releasing README with code coverage badge_


<!-- What's been changed by this PR? -->
#### What is on the PR?

* code-coverage workflow