### PR TITLE
fix: update package name

### DIFF
--- a/.github/workflows/cd-production.yaml
+++ b/.github/workflows/cd-production.yaml
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
       - published
 
 env:
-  PACKAGE_NAME: pkg-15903
+  PACKAGE_NAME: update-pre-commit
   PYTHON_VERSION: '3.12.x'
 
 permissions:


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_package name is not in the CD workflow and causes package validation failure in the post-publish stage.  However, it has no impact to app usage._


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_Fix package name_


<!-- What's been changed by this PR? -->
#### What is on the PR?

* CD production workflow