### PR TITLE
fix: sleep delays validation to ensure publish is complete

### DIFF
--- a/.github/workflows/cd-production.yaml
+++ b/.github/workflows/cd-production.yaml
@@ -58,6 +58,10 @@ jobs:
 
     steps:
 
+    - name: Validate after short wait to ensure publish is complete
+      shell: bash
+      run: sleep 15
+
     - name: Checkout source code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -106,6 +106,10 @@ jobs:
 
     steps:
 
+    - name: Validate after short wait to ensure publish is complete
+      shell: bash
+      run: sleep 15
+
     - name: Checkout source code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_Validation may fail immediately after publish_


<!-- What's the goal of the Pull Request? -->
#### Why is this PR created?

_Create a sleep step to delay the validation_


<!-- What's been changed by this PR? -->
#### What is on the PR?

* CD staging
* CD production