### PR TITLE
fix: coverage run issues: use command_line, simplify Makefile, & use outdated config

### DIFF
--- a/.github/workflows/cron-coverage.yaml
+++ b/.github/workflows/cron-coverage.yaml
@@ -26,31 +26,22 @@ jobs:
       COV_RUN: ${{ steps.get-coverage-results.outputs.COV_RUN }}
 
     steps:
-    - name: Checkout source code
+    - id: checkout-source-code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-    - name: Setup Python
+    - id: setup-Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Install python dependencies
-      run: |
-        make test-install
+    - id: install-python-deps
+      run: make test-install
 
     - id: run-coverage-tests
-      run: |
-        coverage run tests/test_run.py -v
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PYTHONUNBUFFERED: "1"
-
-    - id: export-coverage
-      run: |
-        coverage html
-        coverage report
-      env:
-        PYTHONUNBUFFERED: "1"
+      run: make test
 
     - id: get-coverage-results
       run: |
@@ -59,22 +50,22 @@ jobs:
         echo "COV_RUN=${{ steps.run-coverage-tests.outcome }}"            >> "$GITHUB_OUTPUT"
         echo "COV_PER=$(coverage report | grep TOTAL | awk '{print $6}')" >> "$GITHUB_OUTPUT"
 
-    - name: Upload artifacts
-      id: artifact-upload
+    - id: upload-coverage
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
+        name: coverage
         path: htmlcov/
         if-no-files-found: error
-        retention-days: 3
+        retention-days: 1
         overwrite: true
         compression-level: 6
 
-    - name: Checkout source code of badge branch
+    - id: checkout-source-code-in-badge-branch
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       with:
         ref: badge
 
-    - name: Setup file - coverage.json
+    - id: setup-file-coverage-json
       # create/update coverage.json from template.json
       # { "schemaVersion": 1, "label": "TPL_LABEL", "labelColor": "TPL_LCOLOR", "message": "TPL_MESSAGE", "color": "TPL_COLOR" }
       env:
@@ -87,14 +78,17 @@ jobs:
         # use template.json to create/replace coverage.json
         sed -e 's/TPL_LABEL/${{ env.LABEL }}/g;s/TPL_LCOLOR/${{ env.LCOLOR }}/g;s/TPL_MESSAGE/${{ env.MESSAGE }}/g;s/TPL_COLOR/${{ env.COLOR }}/g' template.json > coverage.json
 
-    - name: Push commits to badge branch
+    - id: push-commits-to-badge-branch
+      shell: bash
       run: |
-        # push commits to badge
-        git config --global user.email "mona-lisa@tagdots.com"
-        git config --global user.name "Mona Lisa"
-        git add coverage.json
-        git commit -m 'create/update coverage.json'
-        git push -u origin badge
+        if [ ! -z "$(git status --porcelain)" ]; then
+          # if the working directory is not clean, push commits to badge
+          git config --global user.email "mona-lisa@github.com"
+          git config --global user.name "Mona Lisa"
+          git add coverage.json
+          git commit -m 'create/update coverage.json'
+          git push -u origin badge
+        fi
 
   notify-slack:
     if: always()

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test:
 	@echo "***************************************************************************"
 	@echo "*** Running coverage tests"
 	@echo "***************************************************************************"
-	coverage run -m unittest -v
+	coverage run
 
 	@echo "\n"
 	@echo "## Create an HTML report of the coverage of the files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,16 @@ dependencies = [
   "virtualenv==20.31.2",
 ]
 
-optional-dependencies.test = [ "build", "commitizen", "coverage", "flake8", "isort", "pre-commit", "pyscan-rs", "twine" ]
+optional-dependencies.test = [
+  "build",
+  "commitizen",
+  "coverage",
+  "flake8",
+  "isort",
+  "pre-commit",
+  "pyscan-rs",
+  "twine",
+]
 
 urls.Changelog = "https://github.com/tagdots/update-pre-commit/blob/main/CHANGELOG.md"
 urls.Documentation = "https://github.com/tagdots/update-pre-commit/blob/main/README.md"
@@ -64,7 +73,7 @@ source = [ "." ]
 
 [tool.coverage.run]
 branch = true
-command_line = "-m unittest discover -s tests/"
+command_line = "-m unittest discover -vs tests/"
 include = [ "src/update_pre_commit/*" ]
 omit = [ "tests/*" ]
 

--- a/src/update_pre_commit/run.py
+++ b/src/update_pre_commit/run.py
@@ -206,7 +206,7 @@ def create_pr(gh, owner_repo, active_branch_name, variance_list, msg_suffix):
 
     print('Creating a Pull Request as follows:')
     print(f'Owner/Repo.  : {owner_repo}')
-    print(f'Title        : {pr_title}{msg_suffix}')
+    print(f'Title        : {pr_title}')
     print(f'Source Branch: {pr_branch}')
     print(f'Target Branch: {pr_base_branch}')
     print(f'Rev Variances: {pr_body}')

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -140,9 +140,9 @@ class TestZMain(unittest.TestCase):
 
     ''' assert zero exit code with dry-run false '''
     def test_main_dry_run_false_success(self):
-        result = self.runner.invoke(main, ['--dry-run', 'False', '--open-pr', 'True'])
-        # print(result.stdout)
-        # print(result.stderr)
+        result = self.runner.invoke(main, ['--file', self.file, '--dry-run', 'False', '--open-pr', 'True'])
+        print(result.stdout)
+        print(result.stderr)
         self.assertEqual(result.exit_code, 0)
 
     ''' assert zero exit code with help '''


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?
**Simplify coverage run**
Update pyproject.toml > tools.coverage.run > command_line to include the -v option that is being used in cron-coverage.yaml and Makefile.

**Fix tests/test_run.py**
If _.pre-commit-config.yaml_ is updated to the latest revs, test_run.py will not be able to run all the tests.  Therefore, test_run.py should point to an outdated default pre-commit configuration file so that coverage run can process all functions.

**Fix cron-coverage.yaml**
Prevent "push commits" when the working directory is clean
