### PR TITLE
Fix/actions

### DIFF
--- a/.github/workflows/cd-production.yaml
+++ b/.github/workflows/cd-production.yaml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      WORKFLOW_RESULT: ${{ steps.get-previous-jobs-results.outputs.WORKFLOW_RESULT }}
+      WORKFLOW_RESULT: ${{ steps.get-overall-jobs-results.outputs.WORKFLOW_RESULT }}
 
     steps:
 

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -134,8 +134,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      WORKFLOW_RESULT: ${{ steps.get-previous-jobs-results.outputs.WORKFLOW_RESULT }}
-      TAG_NAME: ${{ steps.get-previous-jobs-results.outputs.TAG_NAME }}
+      WORKFLOW_RESULT: ${{ steps.get-overall-jobs-results.outputs.WORKFLOW_RESULT }}
+      TAG_NAME: ${{ steps.get-overall-jobs-results.outputs.TAG_NAME }}
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      WORKFLOW_RESULT: ${{ steps.get-previous-jobs-results.outputs.WORKFLOW_RESULT }}
+      WORKFLOW_RESULT: ${{ steps.get-overall-jobs-results.outputs.WORKFLOW_RESULT }}
 
     steps:
 

--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -96,7 +96,6 @@ jobs:
       contents: read
 
     steps:
-
     - name: Run stale-workflow-runs
       id: stale-workflow-runs
       uses: tagdots/delete-workflow-runs-action@563f02090cdf93da6798bcf304238e8ac383c49e # 1.0.2
@@ -131,28 +130,26 @@ jobs:
         stale-issue-message: 'This issue is stale because it has been open 5 days with no activity. Remove stale label or comment or this will be closed in 3 days after stale'
         days-before-stale: 5
         days-before-close: 3
-        operations-per-run: 40
+        delete-branch: true
 
-  stale-branches: # https://github.com/crs-k/stale-branches
+  stale-branches: # https://github.com/tagdots/delete-branches-action
     runs-on: ubuntu-latest
 
     permissions:
-      issues: write
       contents: write
       pull-requests: read
 
     steps:
     - name: Run stale-branches
       id: stale-branches
-      uses: crs-k/stale-branches@de68d9358068be991f64ad9058487e2484925d9a # v8.2.1
+      uses: tagdots/delete-branches-action@fad59ec4b73f3a47a2b8687ec8613e25a832debc # 1.0.2
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        # days-before-stale cannot be greater than or equal to days-before-delete
-        branches-filter-regex: '^((?!main|badge))'
-        days-before-stale: 4
-        days-before-delete: 6
-        include-protected-branches: true
-        pr-check: true
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-url: ${{ github.repository }}
+        max-idle-days: 10
+        exclude-branches: 'badges'
+        dry-run: false
 
   update-pre-commit: # https://github.com/tagdots/update-pre-commit-action
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-codeql.yaml
+++ b/.github/workflows/reusable-codeql.yaml
@@ -34,13 +34,13 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.5
+      uses: github/codeql-action/analyze@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
       with:
         output: codeql-results/
 

--- a/.github/workflows/reusable-dependency-review.yaml
+++ b/.github/workflows/reusable-dependency-review.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  review:
+  review: # https://github.com/actions/dependency-review-action
     runs-on: ubuntu-latest
     steps:
 
@@ -22,3 +22,4 @@ jobs:
         license-check: false
         vulnerability-check: true
         show-openssf-scorecard: false
+        fail-on-severity: low


### PR DESCRIPTION
#### Summary
- fix typos on some workflow actions
- replace action to delete GitHub branches with delete-branches-action
- resolve an issue at codeql-action v3.29.5 where Dependabot updates the hash but not the version comment
- update dependency-review and add "fail-on-severity: low" to the configuration to allow alert of low level vulnerability packages.