### PR TITLE
fix: update github-url

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -97,11 +97,11 @@ jobs:
     steps:
     - name: Run delete-workflow-runs
       id: delete-workflow-runs
-      uses: tagdots/delete-workflow-runs@f2c3f2194a36cb75a380cf33d0a644f6cab7e222 # 1.1.22
+      uses: tagdots/delete-workflow-runs@4303b7da352de2004b0c5f118420cf9f1d63a370 # 1.2.33
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        repo-url: ${{ github.repository }}
+        repo-url: ${{ github.server_url }}/${{ github.repository }}
         max-days: 10
         dry-run: false
 
@@ -141,11 +141,11 @@ jobs:
     steps:
     - name: Run delete-branches
       id: delete-branches
-      uses: tagdots/delete-branches@65148311051bce5e4aacf608d07fce29dad8a2a8 # 1.1.3
+      uses: tagdots/delete-branches@1067f6cf756a462d2da56cffae2df37ea15b600e # 1.2.15
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        repo-url: ${{ github.repository }}
+        repo-url: ${{ github.server_url }}/${{ github.repository }}
         max-idle-days: 10
         exclude-branches: 'badges'
         dry-run: false

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Options:
 
 ```
 (hello-world) ~/work/hello-world $ update-pre-commit --version
-update-pre-commit, version 1.0.0
+update-pre-commit, version 1.2.3
 ```
 
 <br><br>
@@ -90,7 +90,7 @@ By default, **update-pre-commit** implicitly runs `--dry-run true --open-pr fals
 ```
 (hello-world) ~/work/hello-world $ update-pre-commit
 
-Starting update-pre-commit on .pre-commit-config.yaml (dry-run True open-pr False)...
+Starting update-pre-commit (file: .pre-commit-config.yaml, dry-run True open-pr False)...
 
 hadolint/hadolint (v2.11.0) is not using the latest release rev (v2.12.0)
 pycqa/flake8 (7.1.2) is not using the latest release tag (7.2.0)
@@ -111,7 +111,7 @@ Update revs in .pre-commit-config.yaml: None
 ```
 (hello-world) ~/work/hello-world $ update-pre-commit --dry-run false
 
-Starting update-pre-commit on .pre-commit-config.yaml (dry-run False open-pr False)...
+Starting update-pre-commit (file: .pre-commit-config.yaml, dry-run False open-pr False)...
 
 hadolint/hadolint (v2.11.0) is not using the latest release rev (v2.12.0)
 pycqa/flake8 (7.1.2) is not using the latest release tag (7.2.0)
@@ -133,7 +133,7 @@ Update revs in .pre-commit-config.yaml: Success
 ```
 (hello-world) ~/work/hello-world $ update-pre-commit --dry-run false --open-pr true
 
-Starting update-pre-commit on .pre-commit-config.yaml (dry-run False open-pr True)...
+Starting update-pre-commit (file: .pre-commit-config.yaml, dry-run False open-pr True)...
 
 hadolint/hadolint (v2.11.0) is not using the latest release rev (v2.12.0)
 pycqa/flake8 (7.1.2) is not using the latest release tag (7.2.0)


### PR DESCRIPTION
<!-- NOTE: this file is managed by Terraform -->
<!-- Describe the issue -->
#### Issue Summary
_In some cron-tasks, previously, repo-url used "github.repository" in the workflow action context.   The latest release improved error checking and required full GitHub URL.  The issue here is that repo_url in workflow action now needs to prefix with "github.server_url" aka https://github.com per https://docs.github.com/en/actions/reference/workflows-and-actions/contexts_


<!-- What is the goal of the Pull Request? -->
#### Why was this PR created?
- establish repo-url with ${{ github.server_url }}/${{ github.repository }}
- update how-to-examples in README

