### PR TITLE
fix: add a prefix to new branch name to label PR

### DIFF
--- a/src/update_pre_commit/run.py
+++ b/src/update_pre_commit/run.py
@@ -160,7 +160,7 @@ def checkout_new_branch() -> Tuple[str, str]:
     Create a git object to checkout a new branch
     """
     branch_suffix = ulid.new()
-    new_local_branch_name = f'update_pre_commit_{branch_suffix}'
+    new_local_branch_name = f'dep/update_pre_commit_{branch_suffix}'
 
     repo = git.Repo(os.getcwd())
     repo_head_obj = repo.create_head(new_local_branch_name)


### PR DESCRIPTION
<!-- NOTE: this file is managed by Terraform -->
<!-- What is the goal of the Pull Request? -->
#### Why was this PR created?
_With a branch prefix, we can label its associated PR and allow it to be categorized properly in the release_

